### PR TITLE
feat: add custom user speaker identifier feature

### DIFF
--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -39,15 +39,18 @@ export class YesterdayDialog extends MarkdownRenderChild {
 		"tôi",
 		"mình", // Vietnamese
 	];
-
+	
 	allSpeakers: Set<string> = new Set();
 	lastSpeakerByType: Map<string, string> = new Map();
 	lastSpeaker: string | null = null;
 	lastLineElement: HTMLLIElement | null = null;
 
-	constructor(containerEl: HTMLElement, text: string) {
+	constructor(containerEl: HTMLElement, text: string, customUserSpeaker: string) {
 		super(containerEl);
 		this.text = text;
+		if (customUserSpeaker !== ""){
+			this.userSpeakers.push(customUserSpeaker.toLowerCase());
+		}
 	}
 
 	onload() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ interface YesterdaySettings {
 	datePropFormat: string;
 	startOfNextDay: number;
 	customRootFolder: string;
+	customUserSpeaker: string;
 }
 
 const DEFAULT_SETTINGS: YesterdaySettings = {
@@ -34,6 +35,7 @@ const DEFAULT_SETTINGS: YesterdaySettings = {
 	datePropFormat: "YYYY-MM-DD HH:mm:ss Z",
 	startOfNextDay: 5,
 	customRootFolder: "",
+	customUserSpeaker: ""
 };
 
 const DRAFT_SUFFIX = " - draft";
@@ -183,7 +185,7 @@ export default class Yesterday extends Plugin {
 
 				if (isDialog) {
 					context.addChild(
-						new YesterdayDialog(element as HTMLElement, text),
+						new YesterdayDialog(element as HTMLElement, text, this.settings.customUserSpeaker),
 					);
 				}
 
@@ -602,7 +604,7 @@ class YesterdaySettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}),
 			);
-
+		
 		const timeFormatSection = containerEl.createEl("div", {
 			cls: "setting-item setting-item-heading",
 		});
@@ -658,5 +660,18 @@ class YesterdaySettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}),
 			);
+
+		new Setting(containerEl)
+		.setName("Custom My Dialog Idenfier")
+		.setDesc("Set a word to identify yourself in conversation")
+		.addText((text) =>
+			text
+				.setPlaceholder("Bob")
+				.setValue(this.plugin.settings.customUserSpeaker)
+				.onChange(async (value) => {
+					this.plugin.settings.customUserSpeaker = value.trim();
+					await this.plugin.saveSettings();
+				}),
+		);	
 	}
 }


### PR DESCRIPTION
This commit introduces a new feature allowing users to define a custom identifier for themselves in conversation dialogs. The change adds a new setting field `customUserSpeaker` that can be configured through the settings tab. When enabled, this custom identifier is used to better track and distinguish user contributions in dialog-based views.

The implementation includes:
- Adding the new setting to the plugin's configuration
- Updating the dialog constructor to accept the custom speaker identifier
- Integrating the setting into the settings UI with a text input field
- Ensuring proper handling of empty values for the custom speaker

This enhancement provides more flexibility in conversation tracking by allowing users to set their own personal identifiers, making it easier to distinguish user contributions in complex dialog scenarios.